### PR TITLE
Make restaurant menu nullable

### DIFF
--- a/src/routers/graphql/schema.ts
+++ b/src/routers/graphql/schema.ts
@@ -41,7 +41,7 @@ type RestaurantWithDistance {
   address: String
   # Weekly opening hours, first element in array is Monday.
   openingHours: [String]!
-  menu(day: String): Menu!
+  menu(day: String): Menu
   distance: Float!
 }
 
@@ -56,7 +56,7 @@ type Restaurant {
   address: String
   # Weekly opening hours, first element in array is Monday.
   openingHours: [String]!
-  menu(day: String): Menu!
+  menu(day: String): Menu
 }
 
 type Menu {


### PR DESCRIPTION
Quick fix to allow `Menu` as null in the GraphQL schema because sometimes we simply don't have that data.