### PR TITLE
Add menu-parser for Compassgroup

### DIFF
--- a/src/menu-parser/parsers/compassgroup.ts
+++ b/src/menu-parser/parsers/compassgroup.ts
@@ -51,7 +51,7 @@ const parseToCourse = (possiblyCourse: string): Course | null => {
 };
 
 const parser: Parser = {
-  pattern: /compassgroup/,
+  pattern: /(?=.*compassgroup)(?=.*Lounaslista)/,
   async parse(url, lang) {
     const html = await text(url);
     const document = new JSDOM(html).window.document;

--- a/src/menu-parser/parsers/compassgroup.ts
+++ b/src/menu-parser/parsers/compassgroup.ts
@@ -39,6 +39,11 @@ const parseToCourse = (possiblyCourse: string): Course | null => {
     return null;
   }
   const [rawTitle, rawProperties] = possiblyCourse.split(' (');
+
+  if (!rawTitle || !rawProperties) {
+      return null;
+  }
+
   return {
     title: rawTitle.trim(),
     properties: normalizeProperties(rawProperties.match(propertyRegex))

--- a/src/menu-parser/parsers/compassgroup.ts
+++ b/src/menu-parser/parsers/compassgroup.ts
@@ -1,0 +1,43 @@
+import * as moment from 'moment';
+import { JSDOM } from 'jsdom';
+
+import { Parser } from '../index';
+import {
+  text,
+  Property,
+  propertyRegex,
+  createPropertyNormalizer
+} from '../utils';
+
+const dateRegExp = /(\d+).(\d+)./g;
+
+const parseToDate = (possiblyDate: string): string | null => {
+    const match = dateRegExp.exec(possiblyDate);
+    return match
+        ? moment(match[0], "DD.M").format('YYYY-MM-DD')
+        : null;
+}
+
+const parser: Parser = {
+  pattern: /compassgroup/,
+  async parse(url, lang) {
+    const html = await text(url);
+    const document = new JSDOM(html).window.document;
+
+    const container = document.querySelector('#mid-column');
+    const elements = [...container.querySelectorAll('p')];
+
+    return Array.from(elements.reduce((acc: any, curr: any) => {
+        const rowAsDate = parseToDate(curr.textContent);
+        if (rowAsDate) {
+            acc.push({
+                day: rowAsDate,
+                courses: Array.from([])
+            })
+        }
+        return acc;
+    }, []))
+  }
+};
+
+export default parser;

--- a/src/menu-parser/parsers/compassgroup.ts
+++ b/src/menu-parser/parsers/compassgroup.ts
@@ -12,11 +12,38 @@ import {
 const dateRegExp = /(\d+).(\d+)./g;
 
 const parseToDate = (possiblyDate: string): string | null => {
-    const match = dateRegExp.exec(possiblyDate);
-    return match
-        ? moment(match[0], "DD.M").format('YYYY-MM-DD')
-        : null;
-}
+  const match = dateRegExp.exec(possiblyDate);
+  return match
+    ? moment(match[0], 'DD.M').format('YYYY-MM-DD')
+    : null;
+};
+const propertyMap = {
+  PÄ: Property.CONTAINS_ALLERGENS,
+  VS: Property.CONTAINS_ALLERGENS,
+  G: Property.GLUTEN_FREE,
+  V: Property.VEGAN,
+  L: Property.LACTOSE_FREE,
+  M: Property.MILK_FREE,
+  VL: Property.LOW_IN_LACTOSE
+};
+
+const normalizeProperties = createPropertyNormalizer(propertyMap);
+
+interface Course {
+  title: string;
+  properties: Array<Property>;
+};
+
+const parseToCourse = (possiblyCourse: string): Course | null => {
+  if (possiblyCourse.trim() === '') {
+    return null;
+  }
+  const [rawTitle, rawProperties] = possiblyCourse.split(' (');
+  return {
+    title: rawTitle.trim(),
+    properties: normalizeProperties(rawProperties.match(propertyRegex))
+  };
+};
 
 const parser: Parser = {
   pattern: /compassgroup/,
@@ -27,16 +54,26 @@ const parser: Parser = {
     const container = document.querySelector('#mid-column');
     const elements = [...container.querySelectorAll('p')];
 
-    return Array.from(elements.reduce((acc: any, curr: any) => {
-        const rowAsDate = parseToDate(curr.textContent);
-        if (rowAsDate) {
-            acc.push({
-                day: rowAsDate,
-                courses: Array.from([])
-            })
-        }
-        return acc;
-    }, []))
+    const indexOfFirstNotCourseElement = elements.findIndex(
+      e => e.textContent.includes('Muutokset ovat mahdollisia')
+    );
+
+    const courseElements = elements.slice(0, indexOfFirstNotCourseElement - 1);
+
+    return Array.from(courseElements.reduce((acc: any, curr: any) => {
+      const rowAsDate = parseToDate(curr.textContent);
+      if (rowAsDate) {
+        return [...acc, {
+          day: rowAsDate,
+          courses: Array.from([])
+        }];
+      }
+      const rowAsCourse = parseToCourse(curr.textContent);
+      if (rowAsCourse) {
+        acc[acc.length - 1].courses.push(rowAsCourse);
+      }
+      return acc;
+    }, []));
   }
 };
 

--- a/src/menu-parser/parsers/index.ts
+++ b/src/menu-parser/parsers/index.ts
@@ -8,6 +8,7 @@ import ravioli from './ravioli';
 import fazer from './fazer';
 import kipsari from './kipsari';
 import restel from './restel';
+import compassgroup from './compassgroup';
 
 import { Parser } from '../index';
 
@@ -21,7 +22,8 @@ const parsers: Array<Parser> = [
   ravioli,
   fazer,
   kipsari,
-  restel
+  restel,
+  compassgroup
 ];
 
 export default parsers;


### PR DESCRIPTION
As discussed in #16, this PR adds menu parsing support for [ravintola Luova](http://compassgroupfi.episerverhosting.com/Ravintolat/Helsinki/Ravintola-Luova/). Luova seems to be the only one Compass's student lunch restaurant in Helsinki, but I added parser with generic compass group -name anyways. 

The whole menu is listed as `<p>` -elements on Luova's site 😄 Hopefully the parsing process here isn't super fragile.