### PR TITLE
Replace fazer with foodandco in pattern

### DIFF
--- a/src/menu-parser/parsers/amica.ts
+++ b/src/menu-parser/parsers/amica.ts
@@ -54,7 +54,7 @@ async function parseWithDate(url, date) {
 }
 
 const parser: Parser = {
-  pattern: /www\.amica\.fi|www\.fazerfoodco\.fi\/modules/,
+  pattern: /www\.amica\.fi|www\.foodandco\.fi\/modules/,
   async parse(url, lang) {
     url = url.replace('language=fi', 'language=' + lang);
     if (url.match('amica')) {

--- a/src/menu-parser/parsers/fazer.ts
+++ b/src/menu-parser/parsers/fazer.ts
@@ -29,7 +29,7 @@ const normalizeProperties = createPropertyNormalizer({
 });
 
 const parser: Parser = {
-  pattern: /www\.fazerfoodco\.fi\/api/,
+  pattern: /www\.foodandco\.fi\/api/,
   async parse(url, lang) {
     url = url.replace('language=fi', 'language=' + lang);
     const data: MenuFormat = await json(formatUrl(url, moment()));


### PR DESCRIPTION
To fix parsing old Fazer restaurant menus which have been moved under the Foodandco brand and new urls.